### PR TITLE
Fix `<Iterate>` render function parameter typing not inferring correctly

### DIFF
--- a/spec/tests/Iterate.spec.tsx
+++ b/spec/tests/Iterate.spec.tsx
@@ -138,7 +138,7 @@ describe('`Iterate` component', () => {
   it(gray('When given an iterable that yields a value will render correctly'), async () => {
     const channel = new IterableChannelTestHelper<string>();
     let timesRerendered = 0;
-    let lastRenderFnInput: undefined | IterationResult<string>;
+    let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
     const rendered = render(
       <Iterate value={channel}>
@@ -223,7 +223,7 @@ describe('`Iterate` component', () => {
   it(gray('When given an iterable that yields multiple values will render correctly'), async () => {
     const channel = new IterableChannelTestHelper<string>();
     let timesRerendered = 0;
-    let lastRenderFnInput: undefined | IterationResult<string>;
+    let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
     const rendered = render(
       <Iterate value={channel}>
@@ -267,7 +267,7 @@ describe('`Iterate` component', () => {
     async () => {
       const emptyIter = (async function* () {})();
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const rendered = render(
         <Iterate value={emptyIter}>
@@ -333,7 +333,7 @@ describe('`Iterate` component', () => {
     async () => {
       const channel = new IterableChannelTestHelper<string>();
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const rendered = render(
         <Iterate value={channel}>
@@ -380,7 +380,7 @@ describe('`Iterate` component', () => {
         throw simulatedError;
       })();
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const rendered = render(
         <Iterate value={erroringIter}>
@@ -448,7 +448,7 @@ describe('`Iterate` component', () => {
     async () => {
       const channel = new IterableChannelTestHelper<string>();
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const simulatedErr = new Error('...');
 
@@ -495,7 +495,7 @@ describe('`Iterate` component', () => {
       "When consecutively updated with new iterables will close the previous one's iterator every time and render accordingly"
     ),
     async () => {
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const [channel1, channel2] = [
         new IterableChannelTestHelper<string>(),
@@ -585,7 +585,7 @@ describe('`Iterate` component', () => {
   );
 
   it(gray('When unmounted will close the last active iterator it held'), async () => {
-    let lastRenderFnInput: undefined | IterationResult<string>;
+    let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
     const channel = new IterableChannelTestHelper<string>();
     const channelReturnSpy = vi.spyOn(channel, 'return');
@@ -641,7 +641,7 @@ describe('`Iterate` component', () => {
         yield* ['a', 'b', 'c'];
       })();
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
 
       const rendered = render(
         <Iterate value={iter}>
@@ -674,7 +674,7 @@ describe('`Iterate` component', () => {
     ),
     async () => {
       let timesRerendered = 0;
-      let lastRenderFnInput: undefined | IterationResult<string>;
+      let lastRenderFnInput: undefined | IterationResult<string | undefined>;
       const channel = new IterableChannelTestHelper<string>();
 
       const rendered = render(

--- a/src/Iterate/index.tsx
+++ b/src/Iterate/index.tsx
@@ -107,7 +107,10 @@ function Iterate<TVal, TInitialVal = undefined>(props: IterateProps<TVal, TIniti
     typeof props.children === 'function'
       ? (() => {
           const propsBetterTyped = props as IteratePropsWithRenderFunction<TVal, TInitialVal>;
-          const next = useAsyncIter(propsBetterTyped.value, propsBetterTyped.initialValue);
+          const next = useAsyncIter(
+            propsBetterTyped.value,
+            propsBetterTyped.initialValue as TInitialVal
+          );
           return propsBetterTyped.children(next);
         })()
       : (() => {

--- a/src/useAsyncIter/index.ts
+++ b/src/useAsyncIter/index.ts
@@ -99,8 +99,8 @@ export { useAsyncIter, type IterationResult };
  * ```
  */
 const useAsyncIter: {
-  <TVal>(input: TVal, initialVal?: undefined): IterationResult<TVal, undefined>;
-  <TVal, TInitVal = undefined>(input: TVal, initialVal?: TInitVal): IterationResult<TVal, TInitVal>;
+  <TVal>(input: TVal, initialVal?: undefined): IterationResult<TVal>;
+  <TVal, TInitVal>(input: TVal, initialVal: TInitVal): IterationResult<TVal, TInitVal>;
 } = <
   TVal extends
     | undefined
@@ -120,7 +120,7 @@ const useAsyncIter: {
   const rerender = useSimpleRerender();
 
   const stateRef = useRef<IterationResult<TVal, TInitVal>>({
-    value: initialVal,
+    value: initialVal as any,
     pendingFirst: true,
     done: false,
     error: undefined,
@@ -225,12 +225,12 @@ const useAsyncIter: {
 type IterationResult<TVal, TInitVal = undefined> = {
   /**
    * The most recent value received from the async iterable iteration, starting as {@link TInitVal}.
-   * If the source was instead a plain value, it will simply be it.
+   * If the source was a plain value instead, it will simply be it, ignoring any {@link TInitVal}.
    *
-   * Starting to iterate a new async iterable at any future point on itself doesn't reset this;
-   * only some newly resolved next value will.
+   * When the source iterable changes and an iteration restarts with a new iterable, the same last
+   * `value` is carried over and reflected until the new iterable resolves its first value.
    * */
-  value: ExtractAsyncIterValue<TVal> | TInitVal;
+  value: TVal extends AsyncIterable<infer J> ? J | TInitVal : TVal;
 
   /**
    * Indicates whether the iterated async iterable is still pending its own first value to be


### PR DESCRIPTION
Fix `<Iterate>`'s render function parameter type not inferred correctly when `value` prop is given a plain value, in which case it was still considering `initialValue`'s type (or `undefined` on lack of it) as a possibility in the iteration result object's value (but that can't happen since we have a plain non-iterable value which it will render as-is immediately).