### PR TITLE
feat(useAsyncIter): allow initial value to be a function, called once on mount

### DIFF
--- a/src/common/MaybeFunction.ts
+++ b/src/common/MaybeFunction.ts
@@ -1,0 +1,3 @@
+export { MaybeFunction };
+
+type MaybeFunction<T, TPossibleArgs extends unknown[] = []> = T | ((...args: TPossibleArgs) => T);

--- a/src/common/callOrReturn.ts
+++ b/src/common/callOrReturn.ts
@@ -1,0 +1,5 @@
+export { callOrReturn };
+
+function callOrReturn<T>(value: T | (() => T)): T {
+  return typeof value !== 'function' ? value : (value as () => T)();
+}

--- a/src/common/callOrReturn.ts
+++ b/src/common/callOrReturn.ts
@@ -1,5 +1,7 @@
+import { type MaybeFunction } from './MaybeFunction.js';
+
 export { callOrReturn };
 
-function callOrReturn<T>(value: T | (() => T)): T {
+function callOrReturn<T>(value: MaybeFunction<T>): T {
   return typeof value !== 'function' ? value : (value as () => T)();
 }

--- a/src/useAsyncIter/index.ts
+++ b/src/useAsyncIter/index.ts
@@ -3,6 +3,7 @@ import { useLatest } from '../common/hooks/useLatest.js';
 import { isAsyncIter } from '../common/isAsyncIter.js';
 import { useSimpleRerender } from '../common/hooks/useSimpleRerender.js';
 import { useRefWithInitialValue } from '../common/hooks/useRefWithInitialValue.js';
+import { type MaybeFunction } from '../common/MaybeFunction.js';
 import { type ExtractAsyncIterValue } from '../common/ExtractAsyncIterValue.js';
 import {
   reactAsyncIterSpecialInfoSymbol,
@@ -102,7 +103,7 @@ const useAsyncIter: {
   <TVal>(input: TVal, initialVal?: undefined): IterationResult<TVal>;
   <TVal, TInitVal>(
     input: TVal,
-    initialVal: TInitVal | (() => TInitVal)
+    initialVal: MaybeFunction<TInitVal>
   ): IterationResult<TVal, TInitVal>;
 } = <
   TVal extends
@@ -118,7 +119,7 @@ const useAsyncIter: {
   TInitVal,
 >(
   input: TVal,
-  initialVal: TInitVal | (() => TInitVal)
+  initialVal: MaybeFunction<TInitVal>
 ): IterationResult<TVal, TInitVal> => {
   const rerender = useSimpleRerender();
 


### PR DESCRIPTION
This change is basically a breaking change, however isn't communicated as such because library is still considered on a "beta" status at the moment (in a `0.x.x` version range).