### PR TITLE
Handling of async iterables with a current value

### DIFF
--- a/spec/tests/IterateMulti.spec.tsx
+++ b/spec/tests/IterateMulti.spec.tsx
@@ -665,6 +665,72 @@ describe('`IterateMulti` hook', () => {
     }
   );
 
+  describe(
+    gray(
+      'When given multiple iterables with `.value.current` properties at any point, uses these as current values respectively and skips the pending stages'
+    ),
+    () =>
+      [{ initialValues: undefined }, { initialValues: ['_1', '_2'] }].forEach(
+        ({ initialValues }) => {
+          it(
+            gray(
+              `${!initialValues?.length ? 'without initial values' : 'with initial values and ignoring them'}`
+            ),
+            async () => {
+              const renderFn = vi.fn() as Mock<
+                (nexts: IterationResultSet<AsyncIterable<string>[]>) => any
+              >;
+              const [channel1, channel2] = ['__current__1', '__current__2'].map(current =>
+                Object.assign(new IteratorChannelTestHelper<string>(), {
+                  value: { current },
+                })
+              );
+
+              const Component = (props: { values: AsyncIterable<string>[] }) => (
+                <IterateMulti values={props.values}>
+                  {renderFn.mockImplementation(() => (
+                    <div id="test-created-elem">Render count: {renderFn.mock.calls.length}</div>
+                  ))}
+                </IterateMulti>
+              );
+
+              const rendered = render(<></>);
+              const renderedHtmls = [];
+
+              for (const run of [
+                () => act(() => rendered.rerender(<Component values={[channel1]} />)),
+                () => act(() => channel1.put('a')),
+                () => act(() => rendered.rerender(<Component values={[channel2, channel1]} />)),
+                () => act(() => channel2.put('b')),
+              ]) {
+                await run();
+                renderedHtmls.push(rendered.container.innerHTML);
+              }
+
+              expect(renderFn.mock.calls.flat()).toStrictEqual([
+                [{ value: '__current__1', pendingFirst: false, done: false, error: undefined }],
+                [{ value: 'a', pendingFirst: false, done: false, error: undefined }],
+                [
+                  { value: '__current__2', pendingFirst: false, done: false, error: undefined },
+                  { value: 'a', pendingFirst: false, done: false, error: undefined },
+                ],
+                [
+                  { value: 'b', pendingFirst: false, done: false, error: undefined },
+                  { value: 'a', pendingFirst: false, done: false, error: undefined },
+                ],
+              ]);
+              expect(renderedHtmls).toStrictEqual([
+                '<div id="test-created-elem">Render count: 1</div>',
+                '<div id="test-created-elem">Render count: 2</div>',
+                '<div id="test-created-elem">Render count: 3</div>',
+                '<div id="test-created-elem">Render count: 4</div>',
+              ]);
+            }
+          );
+        }
+      )
+  );
+
   it(gray('When unmounted will close all active iterators it has been holding'), async () => {
     const renderFn = vi.fn() as Mock<
       (

--- a/spec/tests/useAsyncIter.spec.ts
+++ b/spec/tests/useAsyncIter.spec.ts
@@ -55,7 +55,7 @@ describe('`useAsyncIter` hook', () => {
 
   it(
     gray(
-      'When given a non-iterable value in conjunction with some initial value will return correct results'
+      'When given a non-iterable value starting in some initial value will return correct results'
     ),
     async () => {
       let timesRerendered = 0;
@@ -99,7 +99,7 @@ describe('`useAsyncIter` hook', () => {
 
   it(
     gray(
-      'When given an iterable that yields a value in conjunction with some initial value will return correct results'
+      'When given an iterable that yields a value starting in some initial value will return correct results'
     ),
     async () => {
       const channel = new IteratorChannelTestHelper<string>();
@@ -183,7 +183,7 @@ describe('`useAsyncIter` hook', () => {
 
   it(
     gray(
-      'When given an iterable that completes without yielding values in conjunction with some initial value will return correct results'
+      'When given an iterable that completes without yielding values starting in some initial value will return correct results'
     ),
     async () => {
       let timesRerendered = 0;
@@ -269,7 +269,7 @@ describe('`useAsyncIter` hook', () => {
 
   it(
     gray(
-      'When given an iterable that errors without yielding values in conjunction with some initial value will return correct results'
+      'When given an iterable that errors without yielding values starting in some initial value will return correct results'
     ),
     async () => {
       let timesRerendered = 0;
@@ -428,6 +428,48 @@ describe('`useAsyncIter` hook', () => {
         { value: 'a', pendingFirst: false, done: false, error: undefined },
       ]);
     }
+  );
+
+  describe(
+    gray(
+      'When given an iterable with a `.value.current` property at any point, uses that as the current value and skips the pending stage'
+    ),
+    () =>
+      [{ initialValue: undefined }, { initialValue: '_' }].forEach(({ initialValue }) => {
+        it(
+          gray(`${!initialValue ? 'without initial value' : 'with initial value and ignoring it'}`),
+          async () => {
+            const [channel1, channel2] = ['__current__1', '__current__2'].map(current =>
+              Object.assign(new IteratorChannelTestHelper<string>(), {
+                value: { current },
+              })
+            );
+
+            const renderedHook = renderHook(props => useAsyncIter(props.channel, initialValue), {
+              initialProps: { channel: undefined as undefined | AsyncIterable<string> },
+            });
+
+            const results: any[] = [];
+
+            for (const run of [
+              () => act(() => renderedHook.rerender({ channel: channel1 })),
+              () => act(() => channel1.put('a')),
+              () => act(() => renderedHook.rerender({ channel: channel2 })),
+              () => act(() => channel2.put('b')),
+            ]) {
+              await run();
+              results.push(renderedHook.result.current);
+            }
+
+            expect(results).toStrictEqual([
+              { value: '__current__1', pendingFirst: false, done: false, error: undefined },
+              { value: 'a', pendingFirst: false, done: false, error: undefined },
+              { value: '__current__2', pendingFirst: false, done: false, error: undefined },
+              { value: 'b', pendingFirst: false, done: false, error: undefined },
+            ]);
+          }
+        );
+      })
   );
 
   it(gray('When unmounted will close the last active iterator it held'), async () => {


### PR DESCRIPTION
When consumed, the initial reported value is the current value, with precedence over any manually supplied initial value, and the "isPending" stage (when `pending: true`) is skipped.