### PR TITLE
Fix `iterateFormatted` typing issue when dealing with "maybe async iterables"

### DIFF
--- a/src/common/AsyncIterableChannel.ts
+++ b/src/common/AsyncIterableChannel.ts
@@ -45,6 +45,7 @@ class AsyncIterableChannel<T, TInit = T> {
       const whenIteratorClosed = promiseWithResolvers<IteratorReturnResult<undefined>>();
       return {
         next: () => {
+          // TODO: Should every iterator of this kind here yield `this.#currentValue` first?...
           return Promise.race([this.#nextIteration.promise, whenIteratorClosed.promise]);
         },
         return: async () => {

--- a/src/iterateFormatted/index.ts
+++ b/src/iterateFormatted/index.ts
@@ -70,7 +70,7 @@ export { iterateFormatted };
  * If `source` is a plain value and not an async iterable, it will be passed to the given `formatFn`
  * and returned on the spot.
  *
- * @template TIn The type of values yielded by the passed iterable or of a plain value passed otherwise.
+ * @template TIn The full type of the source input.
  * @template TRes The type of values resulting after formatting.
  *
  * @param source Any async iterable or plain value.
@@ -78,7 +78,7 @@ export { iterateFormatted };
  *
  * @returns a transformed async iterable emitting every value of `source` after formatting.
  */
-function iterateFormatted<TIn extends AsyncIterable<unknown>, TRes>(
+function iterateFormatted<TIn, TRes>(
   source: TIn,
   formatFn: (
     value: ExtractAsyncIterValue<TIn> | (TIn extends AsyncIterableSubject<infer J> ? J : never),
@@ -88,8 +88,6 @@ function iterateFormatted<TIn extends AsyncIterable<unknown>, TRes>(
   (TIn extends AsyncIterableSubject<unknown>
     ? { value: Required<AsyncIterableSubject<TRes>['value']> }
     : { value: undefined });
-
-function iterateFormatted<TIn, TRes>(source: TIn, formatFn: (value: TIn, i: number) => TRes): TRes;
 
 function iterateFormatted(
   source:


### PR DESCRIPTION
Fix `iterateFormatted`'s type signature not handling "maybe async iterable" type of inputs correctly.