### PR TITLE
eslint to ignore `./dist` dir

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,10 @@ export default [
   ...eslintTs.configs.recommended,
   eslintConfigPrettierTypeForced,
   {
-    files: ['**/*.{ts,ts,tsx,js,mjs,jsx}'],
+    ignores: ['dist/**/*'],
+  },
+  {
+    files: ['**/*.{ts,mts,tsx,js,mjs,jsx}'],
     plugins: {},
     languageOptions: {
       globals: { ...globals.browser },


### PR DESCRIPTION
Ensure that if a `./dist` dir exists (would be true following a build run) then running an eslint check in such case will ignore that dir completely.