### PR TITLE
Fix formatted iterable index argument not accounting for a current-value-holding-iterable correctly

### DIFF
--- a/spec/tests/Iterate.spec.tsx
+++ b/spec/tests/Iterate.spec.tsx
@@ -672,7 +672,7 @@ describe('`Iterate` component', () => {
               }
 
               expect(renderFn.mock.calls.flat()).toStrictEqual(
-                ['a_current', 'a', 'b_current_formatted_0', 'b_formatted_0'].map(value => ({
+                ['a_current', 'a', 'b_current_formatted_0', 'b_formatted_1'].map(value => ({
                   value,
                   pendingFirst: false,
                   done: false,

--- a/spec/tests/IterateMulti.spec.tsx
+++ b/spec/tests/IterateMulti.spec.tsx
@@ -917,7 +917,7 @@ describe('`IterateMulti` hook', () => {
                   { value: 'a', pendingFirst: false, done: false, error: undefined },
                 ],
                 [
-                  { value: 'b_formatted_0', pendingFirst: false, done: false, error: undefined },
+                  { value: 'b_formatted_1', pendingFirst: false, done: false, error: undefined },
                   { value: 'a', pendingFirst: false, done: false, error: undefined },
                 ],
               ]);

--- a/spec/tests/useAsyncIterMulti.spec.ts
+++ b/spec/tests/useAsyncIterMulti.spec.ts
@@ -632,7 +632,7 @@ describe('`useAsyncIterMulti` hook', () => {
                   { value: 'a', pendingFirst: false, done: false, error: undefined },
                 ],
                 [
-                  { value: 'b_formatted_0', pendingFirst: false, done: false, error: undefined },
+                  { value: 'b_formatted_1', pendingFirst: false, done: false, error: undefined },
                   { value: 'a', pendingFirst: false, done: false, error: undefined },
                 ],
               ]);


### PR DESCRIPTION
Fixes the following issue regarding formatting async iterables with current values with `iterateFormatted`'s index argument.

Given an async iterable `myIter` that __starts with a current value__ of `'*'` and yields `'a'` and then `'b'`;

_before the fix we will observe:_
```ts
<It>{iterateFormatted(myIter, (val, i) => `${val}_${i}`)}</It>

/*
  Will render:

  '*_0' and then
  'a_0' and then
  'b_1'
*/
```

_after the fix we will observe:_
```ts
<It>{iterateFormatted(myIter, (val, i) => `${val}_${i}`)}</It>

/*
  Will render:

  '*_0' and then
  'a_1' and then
  'b_2'
*/
```